### PR TITLE
buildspec修正2

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -7,6 +7,9 @@ phases:
   build:
     commands:
       - yarn build
+  post_build:
+    commands:
+      - aws s3 sync dist/ s3://${S3_BUCKET_NAME} --delete
 
 artifacts:
   files:


### PR DESCRIPTION
artifactsでS3にuploadを行うと、ディレクトリ構造が階層になってしまう
公開するHTMLはS3ルート直下にある方が良いため、別のバケットにuploadする